### PR TITLE
fix to socket_status efun

### DIFF
--- a/src/socket_efuns.c
+++ b/src/socket_efuns.c
@@ -1447,7 +1447,8 @@ array_t *socket_status (int which)
                                         "socket_status");
 
     // Fix per Kalinash's suggestion, if (!(lpc_socks[which].flags & STATE_FLUSHING) && ...
-    if (!(lpc_socks[which].flags != STATE_FLUSHING) && lpc_socks[which].owner_ob && !(lpc_socks[which].owner_ob->flags & O_DESTRUCTED)) {
+    // I'm changing it from != back to & and now socket_status tells me the object correctly again.
+    if (!(lpc_socks[which].flags & STATE_FLUSHING) && lpc_socks[which].owner_ob && !(lpc_socks[which].owner_ob->flags & O_DESTRUCTED)) {
         ret->item[5].type = T_OBJECT;
         ret->item[5].u.ob = lpc_socks[which].owner_ob;
         add_ref(lpc_socks[which].owner_ob, "socket_status");

--- a/src/socket_efuns.c
+++ b/src/socket_efuns.c
@@ -1446,8 +1446,6 @@ array_t *socket_status (int which)
     ret->item[4].u.string = string_copy(inet_address(&lpc_socks[which].r_addr),
                                         "socket_status");
 
-    // Fix per Kalinash's suggestion, if (!(lpc_socks[which].flags & STATE_FLUSHING) && ...
-    // I'm changing it from != back to & and now socket_status tells me the object correctly again.
     if (!(lpc_socks[which].flags & STATE_FLUSHING) && lpc_socks[which].owner_ob && !(lpc_socks[which].owner_ob->flags & O_DESTRUCTED)) {
         ret->item[5].type = T_OBJECT;
         ret->item[5].u.ob = lpc_socks[which].owner_ob;


### PR DESCRIPTION
Currently, socket_status will return array of info for an open socket, but the owner object is only included if flags == STATE_FLUSHING.  So undefined is always returned in that info slot.

Instead, it should include the object except when the flags include the STATE_FLUSHING bit.